### PR TITLE
extend spyOn to support both string and symbol methods

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -305,6 +305,47 @@ test('will resets calls', () => {
   expect(fn.results).toEqual([])
 })
 
+test('mocks symbol method', () => {
+  let helloSym = Symbol('hello')
+  let obj = {
+    [helloSym]() {
+      return 'hello'
+    },
+  }
+
+  let method = spyOn(obj, helloSym)
+
+  obj[helloSym]()
+  obj[helloSym]()
+
+  expect(method.called).toBe(true)
+  expect(method.callCount).toBe(2)
+  expect(method.calls).toEqual([[], []])
+  expect(method.results).toEqual([ok('hello'), ok('hello')])
+
+  method.reset()
+
+  expect(method.called).toBe(false)
+  expect(method.callCount).toBe(0)
+  expect(method.calls).toEqual([])
+  expect(method.results).toEqual([])
+
+  method.restore()
+
+  expect(obj[helloSym]()).toEqual('hello')
+})
+
+test('mocks symbol method asserts on unknown symbol', () => {
+  let helloSym = Symbol('hello')
+  let obj = {
+    [helloSym]() {
+      return 'hello'
+    },
+  }
+
+  expect(() => spyOn(obj, Symbol('not-hello'))).toThrow()
+})
+
 // @ts-ignore
 test('asserts', () => {
   expect(() => {


### PR DESCRIPTION
when debugging a [different issue](https://github.com/vitest-dev/vitest/issues/1082#issuecomment-1087175663) we found that tinySpy throws a run time error when trying to spy on a method of an object that is referred to by a symbol.

example:

```typescript
const sym = Symbol('hello')
const obj = {
   [sym]: () => 'hi there'
}

tinySpy.spyOn(obj, sym) // currently throws an error
```

unfortunately, `keyof` in typescript doesn't seem to be as specific with methods indexed by symbols. so type safety isn't as nice as with string methods. thus, run time assertion (which already exists) need to be relied upon for symbols.

with that said, this PR does introduce support for symbol methods. the work mostly required adjusting the types and then allowing symbol methods to be filtered for in one of the metadata functions needed by tinyspy.