### PR TITLE
Support environments which uses commonjs resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "publish": "clean-publish",
     "test": "vitest --no-threads"
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entryPoints: ['src/index.ts'],
   outDir: 'dist',
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   tsconfig: './tsconfig.json',
   target: 'node14',
   minify: false,


### PR DESCRIPTION
This PR fixes importing tinyspy in node and @playwright.test environments as a commonjs module


References:
- [Node.js official docs recommendations](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#writing-dual-packages-while-avoiding-or-minimizing-hazards)