### PR TITLE
feat: allow using "new" keyword with a spy, respect new.target

### DIFF
--- a/src/spy.ts
+++ b/src/spy.ts
@@ -56,7 +56,9 @@ export function spy<A extends any[], R>(cb?: (...args: A) => R): SpyFn<A, R> {
     let type: 'ok' | 'error' = 'ok'
     if (fn.impl) {
       try {
-        result = fn.impl.apply(this, args)
+        result = new.target
+          ? new (fn.impl as any)(...args)
+          : fn.impl.apply(this, args)
         type = 'ok'
       } catch (err: any) {
         result = err

--- a/src/spy.ts
+++ b/src/spy.ts
@@ -28,9 +28,12 @@ export interface SpyImpl<A extends any[] = any[], R = any> extends Spy<A, R> {
 
 export interface SpyFn<A extends any[] = any[], R = any> extends Spy<A, R> {
   (...args: A): R
+  new (...args: A): R
 }
 
-export function spy<A extends any[], R>(cb?: (...args: A) => R): SpyFn<A, R> {
+export function spy<A extends any[], R>(
+  cb?: ((...args: A) => R) | { new (...args: A): R }
+): SpyFn<A, R> {
   assert(
     isType('function', cb) || isType('undefined', cb),
     'cannot spy on a non-function value'
@@ -100,7 +103,7 @@ export function spy<A extends any[], R>(cb?: (...args: A) => R): SpyFn<A, R> {
     fn.calls = []
   }
   reset()
-  fn.impl = cb
+  fn.impl = cb as any
   fn.reset = reset
   fn.nextError = (error: any) => {
     fn.next = ['error', error]

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { spyOn } from '../src'
+import { spyOn, spy } from '../src'
 
 class Dep {
   run(): boolean {
@@ -23,5 +23,24 @@ describe('class mock', () => {
 
     expect(spy1.callCount).toBe(1)
     expect(spy2.callCount).toBe(1)
+  })
+
+  test('throws error, if constructor is an arrow function', () => {
+    const fnArrow = spy(() => {})
+    expect(() => new fnArrow()).toThrowError()
+  })
+
+  test('respects new.target', () => {
+    let target: unknown = null
+    let args: unknown[] = []
+    const fnScoped = spy(function (...fnArgs: unknown[]) {
+      target = new.target
+      args = fnArgs
+    })
+
+    new fnScoped('some', 'text', 1)
+    expect(target).toBeTypeOf('function')
+    expect(args).toEqual(['some', 'text', 1])
+    expect(fnScoped.calls).toEqual([['some', 'text', 1]])
   })
 })

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -30,13 +30,31 @@ describe('class mock', () => {
     expect(() => new fnArrow()).toThrowError()
   })
 
-  test('respects new.target', () => {
+  test('respects new.target in a function', () => {
     let target: unknown = null
     let args: unknown[] = []
     const fnScoped = spy(function (...fnArgs: unknown[]) {
       target = new.target
       args = fnArgs
     })
+
+    new fnScoped('some', 'text', 1)
+    expect(target).toBeTypeOf('function')
+    expect(args).toEqual(['some', 'text', 1])
+    expect(fnScoped.calls).toEqual([['some', 'text', 1]])
+  })
+
+  test('respects new.target in a class', () => {
+    let target: unknown = null
+    let args: unknown[] = []
+    const fnScoped = spy(
+      class {
+        constructor(...fnArgs: unknown[]) {
+          target = new.target
+          args = fnArgs
+        }
+      }
+    )
 
     new fnScoped('some', 'text', 1)
     expect(target).toBeTypeOf('function')


### PR DESCRIPTION
Fixes #29