### PR TITLE
Improve getDescriptor for inherited methods

### DIFF
--- a/src/spyOn.ts
+++ b/src/spyOn.ts
@@ -23,6 +23,9 @@ type Constructors<T> = {
 
 let getDescriptor = (obj: any, method: string | symbol | number) => {
   let objDescriptor = Object.getOwnPropertyDescriptor(obj, method)
+  if (objDescriptor) {
+    return objDescriptor
+  }
   let currentProto = Object.getPrototypeOf(obj)
   while (currentProto !== null) {
     const descriptor = Object.getOwnPropertyDescriptor(currentProto, method)
@@ -31,7 +34,6 @@ let getDescriptor = (obj: any, method: string | symbol | number) => {
     }
     currentProto = Object.getPrototypeOf(currentProto)
   }
-  return objDescriptor
 }
 
 let prototype = (fn: any, val: any) => {

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -149,7 +149,36 @@ describe('class mock', () => {
     const foo = new Foo()
     spyOn(foo, { getter: 'bar' }, () => 'foo')
     expect(foo.bar).toEqual('foo')
-    foo.bar = 'baz'
+    // foo.bar setter is inherited from Bar, so we can set it
+    expect(() => {
+      foo.bar = 'baz'
+    }).not.toThrowError()
+    expect(foo.bar).toEqual('foo')
+  })
+
+  test('mocks inherited overridden methods', () => {
+    class Bar {
+      _bar = 'bar'
+      get bar(): string {
+        return this._bar
+      }
+      set bar(bar: string) {
+        this._bar = bar
+      }
+    }
+    class Foo extends Bar {
+      get bar(): string {
+        return `${super.bar}-foo`
+      }
+    }
+    const foo = new Foo()
+    expect(foo.bar).toEqual('bar-foo')
+    spyOn(foo, { getter: 'bar' }, () => 'foo')
+    expect(foo.bar).toEqual('foo')
+    // foo.bar setter is not inherited from Bar
+    expect(() => {
+      foo.bar = 'baz'
+    }).toThrowError()
     expect(foo.bar).toEqual('foo')
   })
 })

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -134,4 +134,22 @@ describe('class mock', () => {
       "Class constructor _Mock cannot be invoked without 'new'"
     )
   })
+
+  test('mocks inherited methods', () => {
+    class Bar {
+      _bar = 'bar'
+      get bar(): string {
+        return this._bar
+      }
+      set bar(bar: string) {
+        this._bar = bar
+      }
+    }
+    class Foo extends Bar {}
+    const foo = new Foo()
+    spyOn(foo, { getter: 'bar' }, () => 'foo')
+    expect(foo.bar).toEqual('foo')
+    foo.bar = 'baz'
+    expect(foo.bar).toEqual('foo')
+  })
 })


### PR DESCRIPTION
When looking for getter/setter descriptor, we should go deeper for prototypes.

Fixes  #49 

`getDescriptor` will now "dig" until it finds `getOwnPropertyDescriptor` or there are no more `getPrototypeOf` available.